### PR TITLE
Upgrade to XP 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,9 @@ plugins {
 	id 'java' // Needed for assemble and build
 	id 'maven-publish' // Provides publishing and publishToMavenLocal
 	id 'com.enonic.defaults' version '2.1.6' // Publishing
-	id 'com.enonic.xp.app' version '3.6.2'
+	id 'com.enonic.xp.app'
 	id 'com.github.node-gradle.node' version '7.1.0'
 }
-
-// XP 7.12 and below requires Java 11
-// compileJava {
-// 	options.release = 17
-// }
 
 repositories {
 	mavenLocal()
@@ -18,63 +13,48 @@ repositories {
 }
 
 
-app {
-	name = project.appName
-	group = 'com.enonic.app'
-	displayName = 'Explorer'
-	vendorName = 'Enonic AS'
-	vendorUrl = 'https://enonic.com'
-	systemVersion = "${xpVersion}"
-}
-
-
 dependencies {
-	implementation "com.enonic.xp:core-api:${xpVersion}"
-	implementation "com.enonic.xp:portal-api:${xpVersion}"
+	implementation xplibs.api.core
+	implementation xplibs.api.portal
 
 	//──────────────────────────────────────────────────────────────────────────
 	// Core libs (com.enonic.xp)
 	//──────────────────────────────────────────────────────────────────────────
 
-	include "com.enonic.xp:lib-admin:${xpVersion}"
-	include "com.enonic.xp:lib-app:${xpVersion}"
-	include "com.enonic.xp:lib-auth:${xpVersion}"
-	include "com.enonic.xp:lib-cluster:${xpVersion}" // src/main/resources/main.ts:import {isMaster} from '/lib/xp/cluster';
-	include "com.enonic.xp:lib-common:${xpVersion}"
-	include "com.enonic.xp:lib-context:${xpVersion}" // Needed by lib-explorer
-	include "com.enonic.xp:lib-event:${xpVersion}"
-	include "com.enonic.xp:lib-i18n:${xpVersion}" // Needed by lib-explorer
-	include "com.enonic.xp:lib-io:${xpVersion}"
-	include "com.enonic.xp:lib-mail:${xpVersion}" // Needed by lib-explorer
-	include "com.enonic.xp:lib-node:${xpVersion}" // Needed by lib-explorer
-	include "com.enonic.xp:lib-portal:${xpVersion}"
-	include "com.enonic.xp:lib-project:${xpVersion}"
-	include "com.enonic.xp:lib-repo:${xpVersion}"
-	include "com.enonic.xp:lib-scheduler:${xpVersion}"
-	include "com.enonic.xp:lib-schema:${xpVersion}"
-	include "com.enonic.xp:lib-task:${xpVersion}"
-	//include "com.enonic.xp:lib-thymeleaf:${xpVersion}"
-	include "com.enonic.xp:lib-vhost:${xpVersion}"
-	include "com.enonic.xp:lib-websocket:${xpVersion}"
+	include xplibs.admin
+	include xplibs.app
+	include xplibs.auth
+	include xplibs.cluster // src/main/resources/main.ts:import {isMaster} from '/lib/xp/cluster';
+	include xplibs.common
+	include xplibs.context // Needed by lib-explorer
+	include xplibs.event
+	include xplibs.i18n // Needed by lib-explorer
+	include xplibs.io
+	include xplibs.mail // Needed by lib-explorer
+	include xplibs.node // Needed by lib-explorer
+	include xplibs.portal
+	include xplibs.project
+	include xplibs.repo
+	include xplibs.scheduler
+	include xplibs.schema
+	include xplibs.task
+	//include xplibs.thymeleaf
+	include xplibs.vhost
+	include xplibs.websocket
 
 	//──────────────────────────────────────────────────────────────────────────
 	// Other enonic libs (com.enonic.lib)
 	//──────────────────────────────────────────────────────────────────────────
 
-	//include 'com.enonic.lib:lib-admin-ui:3.0.0' // Not needed for the XP Menu
-
-	include 'com.enonic.lib:lib-cache:2.2.1'
-	include 'com.enonic.lib:lib-graphql:2.1.0'
-	//include 'com.enonic.lib:lib-graphql-playground:0.0.1'
-	include 'com.enonic.lib:lib-guillotine:6.2.1'
-	include 'com.enonic.lib:lib-http-client:3.2.2'
-	include 'com.enonic.lib:lib-license:3.1.0'
-	include 'com.enonic.lib:lib-router:3.2.0'
-	// include 'com.enonic.lib:lib-asset:1.0.0'
-	include 'com.enonic.lib:lib-static:2.1.1'
-	include 'com.enonic.lib:lib-explorer:4.5.0'
-	include 'com.enonic.lib:lib-util:3.1.1' //lib/util/content/getSites
-	// include 'com.enonic.lib:lib-text-encoding:2.0.0'
+	include libs.lib.cache
+	include libs.lib.graphql
+	include libs.lib.guillotine
+	include libs.lib.http.client
+	include libs.lib.license
+	include libs.lib.router
+	include libs.lib.static
+	include libs.lib.explorer
+	include libs.lib.util
 
 	// WARNING: Do NOT use include files, jar file will be missing dependencies!
 }
@@ -82,10 +62,6 @@ dependencies {
 
 tasks.withType(Copy) {
   includeEmptyDirs = false
-}
-
-wrapper {
-	distributionUrl = "${gradleDistributionUrl}"
 }
 
 node {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,11 @@ projectName=explorer
 appName=com.enonic.app.explorer
 rootProjectName=explorer
 
-# lib-static-2.0.0 requires 7.14.0
-xpVersion=7.14.0
+appDisplayName=Explorer
+vendorName=Enonic AS
+vendorUrl=https://enonic.com
 
-gradleDistributionUrl=https://services.gradle.org/distributions/gradle-8.14.3-all.zip
+xpVersion=8.0.0-B4
 
 nodeVersion=22.19.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,6 @@ projectName=explorer
 appName=com.enonic.app.explorer
 rootProjectName=explorer
 
-appDisplayName=Explorer
-vendorName=Enonic AS
-vendorUrl=https://enonic.com
-
 xpVersion=8.0.0-B4
 
 nodeVersion=22.19.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,21 @@
+[versions]
+lib-cache = "2.2.1"
+lib-graphql = "2.1.0"
+lib-guillotine = "6.2.1"
+lib-http-client = "3.2.2"
+lib-license = "3.1.0"
+lib-router = "3.2.0"
+lib-static = "2.1.1"
+lib-explorer = "4.5.0"
+lib-util = "3.1.1"
+
+[libraries]
+lib-cache = { module = "com.enonic.lib:lib-cache", version.ref = "lib-cache" }
+lib-graphql = { module = "com.enonic.lib:lib-graphql", version.ref = "lib-graphql" }
+lib-guillotine = { module = "com.enonic.lib:lib-guillotine", version.ref = "lib-guillotine" }
+lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "lib-http-client" }
+lib-license = { module = "com.enonic.lib:lib-license", version.ref = "lib-license" }
+lib-router = { module = "com.enonic.lib:lib-router", version.ref = "lib-router" }
+lib-static = { module = "com.enonic.lib:lib-static", version.ref = "lib-static" }
+lib-explorer = { module = "com.enonic.lib:lib-explorer", version.ref = "lib-explorer" }
+lib-util = { module = "com.enonic.lib:lib-util", version.ref = "lib-util" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+	id 'com.enonic.xp.settings' version '4.0.0-B1'
+}
+
 rootProject.name = rootProjectName

--- a/src/main/resources/admin/tools/explorer/explorer.yaml
+++ b/src/main/resources/admin/tools/explorer/explorer.yaml
@@ -1,0 +1,8 @@
+kind: "AdminTool"
+title:
+  text: "Explorer"
+description:
+  text: "Enterprise search"
+allow:
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,5 @@
+kind: "Application"
+title: "Explorer"
+description: ""
+vendorName: "Enonic AS"
+vendorUrl: "https://enonic.com"

--- a/src/main/resources/services/attachment/attachment.yaml
+++ b/src/main/resources/services/attachment/attachment.yaml
@@ -1,0 +1,5 @@
+kind: "Service"
+title: "attachment"
+allow:
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"

--- a/src/main/resources/services/collectionCollect/collectionCollect.yaml
+++ b/src/main/resources/services/collectionCollect/collectionCollect.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "collectionCollect"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/services/collectionDuplicate/collectionDuplicate.yaml
+++ b/src/main/resources/services/collectionDuplicate/collectionDuplicate.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "collectionDuplicate"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/services/collectorAssets/collectorAssets.yaml
+++ b/src/main/resources/services/collectorAssets/collectorAssets.yaml
@@ -1,0 +1,5 @@
+kind: "Service"
+title: "collectorAssets"
+allow:
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"

--- a/src/main/resources/services/collectorStop/collectorStop.yaml
+++ b/src/main/resources/services/collectorStop/collectorStop.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "collectorStop"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/services/explorerAssets/explorerAssets.yaml
+++ b/src/main/resources/services/explorerAssets/explorerAssets.yaml
@@ -1,0 +1,5 @@
+kind: "Service"
+title: "explorerAssets"
+allow:
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"

--- a/src/main/resources/services/graphQL/graphQL.yaml
+++ b/src/main/resources/services/graphQL/graphQL.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "graphQL"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/services/icon/icon.yaml
+++ b/src/main/resources/services/icon/icon.yaml
@@ -1,0 +1,5 @@
+kind: "Service"
+title: "icon"
+allow:
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"

--- a/src/main/resources/services/interfaceCopy/interfaceCopy.yaml
+++ b/src/main/resources/services/interfaceCopy/interfaceCopy.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "interfaceCopy"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/services/interfaceExists/interfaceExists.yaml
+++ b/src/main/resources/services/interfaceExists/interfaceExists.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "interfaceExists"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/services/journals/journals.yaml
+++ b/src/main/resources/services/journals/journals.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "journals"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/services/listCollectors/listCollectors.yaml
+++ b/src/main/resources/services/listCollectors/listCollectors.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "listCollectors"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/services/longPolling/longPolling.yaml
+++ b/src/main/resources/services/longPolling/longPolling.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "longPolling"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/services/notifications/notifications.yaml
+++ b/src/main/resources/services/notifications/notifications.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "notifications"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/services/thesaurusExport/thesaurusExport.yaml
+++ b/src/main/resources/services/thesaurusExport/thesaurusExport.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "thesaurusExport"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/services/uninstallLicense/uninstallLicense.yaml
+++ b/src/main/resources/services/uninstallLicense/uninstallLicense.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "uninstallLicense"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/services/uploadLicense/uploadLicense.yaml
+++ b/src/main/resources/services/uploadLicense/uploadLicense.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "uploadLicense"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/services/ws/ws.yaml
+++ b/src/main/resources/services/ws/ws.yaml
@@ -1,0 +1,11 @@
+kind: "Service"
+title: "ws"
+allow:
+  - "role:cms.admin"
+  - "role:cms.cm.app"
+  - "role:cms.expert"
+  - "role:com.enonic.app.explorer.admin"
+  - "role:system.admin"
+  - "role:system.admin.login"
+  - "role:system.authenticated"
+  - "role:system.everyone"

--- a/src/main/resources/tasks/concisePermissions/concisePermissions.yaml
+++ b/src/main/resources/tasks/concisePermissions/concisePermissions.yaml
@@ -1,0 +1,3 @@
+kind: "Task"
+description: "Concise permissions"
+form: []

--- a/src/main/resources/tasks/import_csv_to_thesaurus/import_csv_to_thesaurus.yaml
+++ b/src/main/resources/tasks/import_csv_to_thesaurus/import_csv_to_thesaurus.yaml
@@ -1,0 +1,27 @@
+kind: "Task"
+description: "Import CSV to Thesaurus"
+form:
+  - type: "TextLine"
+    name: "csv"
+    label: "csv"
+    occurrences:
+      min: 1
+      max: 1
+  - type: "TextLine"
+    name: "fromLocale"
+    label: "fromLocale"
+    occurrences:
+      min: 1
+      max: 1
+  - type: "TextLine"
+    name: "thesaurusId"
+    label: "thesaurusId"
+    occurrences:
+      min: 1
+      max: 1
+  - type: "TextLine"
+    name: "toLocale"
+    label: "toLocale"
+    occurrences:
+      min: 1
+      max: 1

--- a/src/main/resources/tasks/init/init.yaml
+++ b/src/main/resources/tasks/init/init.yaml
@@ -1,0 +1,3 @@
+kind: "Task"
+description: "Init"
+form: []

--- a/src/main/resources/tasks/migrate/migrate.yaml
+++ b/src/main/resources/tasks/migrate/migrate.yaml
@@ -1,0 +1,3 @@
+kind: "Task"
+description: "Migrate"
+form: []

--- a/src/main/resources/tasks/migrate_thesaurus_synonyms_v1_to_v2/migrate_thesaurus_synonyms_v1_to_v2.yaml
+++ b/src/main/resources/tasks/migrate_thesaurus_synonyms_v1_to_v2/migrate_thesaurus_synonyms_v1_to_v2.yaml
@@ -1,0 +1,21 @@
+kind: "Task"
+description: "Migrate Thesaurus Synonyms v1 to v2"
+form:
+  - type: "TextLine"
+    name: "thesaurusId"
+    label: "Thesaurus ID"
+    occurrences:
+      min: 1
+      max: 1
+  - type: "TextLine"
+    name: "fromLocale"
+    label: "From locale"
+    occurrences:
+      min: 1
+      max: 1
+  - type: "TextLine"
+    name: "toLocale"
+    label: "To locale"
+    occurrences:
+      min: 1
+      max: 1

--- a/src/main/resources/tasks/reindexCollection/reindexCollection.yaml
+++ b/src/main/resources/tasks/reindexCollection/reindexCollection.yaml
@@ -1,0 +1,15 @@
+kind: "Task"
+description: "Reindex collection"
+form:
+  - type: "TextLine"
+    name: "collectionJson"
+    label: "Collection JSON"
+    occurrences:
+      min: 1
+      max: 1
+  - type: "TextLine"
+    name: "documentTypeJson"
+    label: "Document Type JSON"
+    occurrences:
+      min: 1
+      max: 1


### PR DESCRIPTION
## Summary

XP 7 → XP 8 platform upgrade following the [`xp-app-upgrader`](https://github.com/enonic/ai-agents-skills/tree/master/skills/xp-app-upgrader) workflow.

**`xpVersion`: `7.14.0` → `8.0.0-B4`**

### Categories of changes

- **Settings plugin**: `settings.gradle` declares `com.enonic.xp.settings` v4.0.0-B1 (supplies plugin version + dependency catalog).
- **Build files**: `build.gradle` drops the `version '3.6.2'` pin from `com.enonic.xp.app`, removes the `app { }` and `wrapper { }` blocks, and switches dependencies to the catalog. `appDisplayName` / `vendorName` / `vendorUrl` move from `build.gradle` to `gradle.properties`. `gradleDistributionUrl` removed.
- **Dependencies aliased**: `com.enonic.xp:core-api` / `portal-api` → `xplibs.api.*`; 19 `com.enonic.xp:lib-*` deps → `xplibs.*`; 9 third-party `com.enonic.lib:*` deps moved to a new `gradle/libs.versions.toml` and referenced as `libs.lib.*`.
- **Gradle wrapper**: 8.14.3 → 9.4.1.
- **Descriptors converted (26 files, all hand-migrated — `xp8migrator` native binary cannot run on this CI runner due to missing AVX2/BMI2 CPU features; followed the manual rules from `references/manual-schemes-migration.md`)**:
  - `application.xml` → `application.yaml` (`kind: Application`)
  - `admin/tools/explorer/explorer.xml` → `.yaml` (`kind: AdminTool`, `title` / `description` as `{ text }` objects, `allow` as list)
  - 18 `services/*/*.xml` → `.yaml` (`kind: Service`)
  - 6 `tasks/*/*.xml` → `.yaml` (`kind: Task`, forms with `occurrences: { min, max }`)

### What is **not** in this PR

- **Cleanup of original `.xml` files** is intentionally deferred. Per the skill's `Validate before deletion` rule, originals must remain until `./gradlew clean build` is green. See blocker below.
- **No `site/` tree existed**, so no `cms/` migration was needed.
- **No admin widgets / APIs / idprovider / webapp.xml**, so nothing to migrate in those categories.
- **Runtime verification (`./gradlew clean deploy`) was not performed** — out of scope for this upgrade run.

## :warning: Blocker — upstream libraries not yet on XP 8

`./gradlew clean build` currently fails at `:includeCopy` configuration resolution. The XP 8 `com.enonic.xp.app` plugin enforces a systemVersion check on every included `com.enonic.xp:lib-*` artifact, and two third-party deps are pulling in XP 7 versions:

```
> Could not resolve com.enonic.xp:lib-context:7.12.1.
  Required by:
      root project 'explorer' > com.enonic.lib:lib-guillotine:6.2.1
   > Included dependency com.enonic.xp:lib-context:7.12.1 is incompatible with app systemVersion 8.0.0-B4

> Could not resolve com.enonic.xp:lib-context:7.14.0.
  Required by:
      root project 'explorer' > com.enonic.lib:lib-explorer:4.5.0
   > Included dependency com.enonic.xp:lib-context:7.14.0 is incompatible with app systemVersion 8.0.0-B4
```

…and similar for ~20 other transitive `com.enonic.xp:lib-*` artifacts.

**Root cause**: `com.enonic.lib:lib-guillotine` (latest stable 6.2.1, latest snapshot 6.2.2-SNAPSHOT) and `com.enonic.lib:lib-explorer` (latest stable 4.5.0, latest snapshot 4.5.1-SNAPSHOT) **both still declare XP 7 as their systemVersion**. I checked `repo.enonic.com/dev` for newer SNAPSHOT lines — nothing exists for XP 8. No `lib-explorer` 5.x, no `lib-guillotine` 7.x.

**Unblocking path** (out of scope for this PR):
1. Publish an XP 8-compatible `lib-explorer` (likely a 5.0.0 line).
2. Publish an XP 8-compatible `lib-guillotine` (likely 7.0.0).
3. Bump those versions in `gradle/libs.versions.toml` here.
4. Re-run `./gradlew clean build`; if green, drop the 26 legacy `.xml` files.

### Heads-up: removed lib-admin API in client code

Not a build blocker, but worth flagging for follow-up: `src/main/resources/admin/tools/explorer/htmlResponse.ts` calls `getLauncherPath()` from `/lib/xp/admin`, which the [XP 8 upgrade guide](https://github.com/enonic/ai-agents-skills/blob/master/skills/xp-app-upgrader/references/app-upgrade-xp8.md) lists as removed. Will need a runtime-side fix once the build blocker is cleared.

## Test plan

- [ ] Resolve upstream blocker (publish XP 8 builds of `lib-explorer` and `lib-guillotine`)
- [ ] Re-run `./gradlew clean build` — must be green
- [ ] After green build, delete the 26 `.xml` originals (keep only the new `.yaml` files)
- [ ] Replace `getLauncherPath()` call in `htmlResponse.ts`
- [ ] Smoke-test runtime deployment against an XP 8 instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)