### PR TITLE
Bump version to 5.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            4.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ xpVersion=8.0.0-B4
 
 nodeVersion=22.19.0
 
-version=4.6.1-SNAPSHOT
+version=5.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Bump master `version` to `5.0.0-SNAPSHOT` (was `4.6.1-SNAPSHOT`) so master is the XP 8 mainline.
- Add `releaseBranch:` configuration to `enonic-gradle.yml` listing both `master` and `4.x` so the new maintenance branch is recognized by the release tooling.
- The `4.x` maintenance branch was created from SHA `67af3b2d134d6518a21f4eec87604657ecf3d0b4` (the post-`v4.6.0` "Updated to next SNAPSHOT version" commit). A companion PR against `4.x` adds the same workflow change.

## Test plan
- [ ] CI build is green on this PR
- [ ] After merge, `./gradlew clean build` from master is green