### PR TITLE
Add release-branch CI config for 4.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            4.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `releaseBranch:` configuration to `enonic-gradle.yml` listing both `master` and `4.x`.
- This is required so pushes to `4.x` are recognized as release-branch builds — the release action reads `releaseBranch:` from the branch's own workflow file.
- Companion to the master-side PR (#1018) which performs the version bump to `5.0.0-SNAPSHOT` and the same workflow change.
- No version bump or other master-only changes are included here, per the app-booster reference.

## Test plan
- [ ] CI run on `4.x` (after merge) classifies it as a release branch