### PR TITLE
Drop lib-util in favour of lib-explorer helpers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ dependencies {
 	include libs.lib.router
 	include libs.lib.static
 	include libs.lib.explorer
-	include libs.lib.util
 
 	// WARNING: Do NOT use include files, jar file will be missing dependencies!
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ lib-license = "3.1.0"
 lib-router = "3.2.0"
 lib-static = "2.1.1"
 lib-explorer = "5.0.0-SNAPSHOT"
-lib-util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-cache = { module = "com.enonic.lib:lib-cache", version.ref = "lib-cache" }
@@ -18,4 +17,3 @@ lib-license = { module = "com.enonic.lib:lib-license", version.ref = "lib-licens
 lib-router = { module = "com.enonic.lib:lib-router", version.ref = "lib-router" }
 lib-static = { module = "com.enonic.lib:lib-static", version.ref = "lib-static" }
 lib-explorer = { module = "com.enonic.lib:lib-explorer", version.ref = "lib-explorer" }
-lib-util = { module = "com.enonic.lib:lib-util", version.ref = "lib-util" }

--- a/src/main/resources/services/graphQL/content/addGetSites.ts
+++ b/src/main/resources/services/graphQL/content/addGetSites.ts
@@ -18,7 +18,7 @@ import {
 import { serviceUrl } from '/lib/xp/portal';
 import { list as listProjects } from '/lib/xp/project';
 // @ts-ignore
-import { getSites as gS } from '/lib/util/content/getSites';
+import { getSites as gS } from '/lib/explorer/content/getSites';
 
 import type {
 	Env,

--- a/src/main/resources/webapp/interface/post.test.ts
+++ b/src/main/resources/webapp/interface/post.test.ts
@@ -164,9 +164,6 @@ jest.mock('/lib/graphql-connection', () => ({
 jest.mock('/lib/guillotine/util/factory', () => ({
 }), { virtual: true });
 
-jest.mock('/lib/util', () => ({
-}), { virtual: true });
-
 jest.mock('/lib/xp/context', () => ({
 	get: jest.fn<typeof get>().mockReturnValue({
 		attributes: {},

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -123,7 +123,6 @@ export default defineConfig((options: MyOptions) => {
 				'/lib/http-client',
 				'/lib/license',
 				'/lib/router',
-				'/lib/util',
 				'/lib/vanilla',
 				'/lib/text-encoding',
 				'/lib/thymeleaf',


### PR DESCRIPTION
## Summary

- Switch the one `/lib/util/content/getSites` import in `services/graphQL/content/addGetSites.ts` to `/lib/explorer/content/getSites`.
- Helper is vendored in lib-explorer PR enonic/lib-explorer#386 — both apps in the cluster already pin `lib-explorer = "5.0.0-SNAPSHOT"`, so no version bump needed once that lands.
- Drop `lib-util` from `gradle/libs.versions.toml`, the `include` in `build.gradle`, the `/lib/util` external in `tsup.config.ts`, and the matching `jest.mock('/lib/util', …)` stub in `webapp/interface/post.test.ts`.

## Depends on

- enonic/lib-explorer#386 — once merged and the new lib-explorer SNAPSHOT is published, CI here will be able to resolve `/lib/explorer/content/getSites`. Locally, refreshing the symlinks/lib-explorer checkout (or rerunning the Coverage workflow) is enough.

## Test plan

- [x] `npm run build` (clean) — emits chunks referencing `/lib/explorer/content/getSites`; no stray `/lib/util` left in `build/resources/main/`.
- [x] `git grep '/lib/util'` returns nothing under tracked files.
- [ ] `./gradlew build` is pre-existing-broken on master (lib-guillotine 6.2.1 pulls XP 7.12.1 transitives incompatible with XP 8.0.0-B4). Same failure with or without this PR — not addressed here.
- [ ] `npm test` Coverage CI is pre-existing-broken on master (TS errors in lib-explorer source consumed via `symlinks/`). Same failures on master and this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)