### PR TITLE
GraalJS Compatibility #1082

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,15 @@ dependencies {
 	include libs.lib.explorer
 
 	// WARNING: Do NOT use include files, jar file will be missing dependencies!
+
+	//──────────────────────────────────────────────────────────────────────────
+	// Test (runs the JS on the real script engine, once per engine)
+	//──────────────────────────────────────────────────────────────────────────
+
+	testImplementation "com.enonic.xp:testing:${xpVersion}"
+	testImplementation 'org.junit.jupiter:junit-jupiter:6.1.1'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 
@@ -158,3 +167,27 @@ tasks.register('compressAssets', NpmTask) {
 }
 // TODO: Use if switch to lib-asset
 // jar.dependsOn compressAssets
+
+// The JS tests run the compiled bundle on the real engine, so it must exist on
+// build/resources/main before the test sources are compiled and executed.
+tasks.named('compileTestJava') {
+	dependsOn npmBuild
+}
+
+test {
+	dependsOn npmBuild
+	useJUnitPlatform()
+}
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+	group = 'verification'
+	description = 'Runs tests with the GraalJS script engine.'
+	dependsOn npmBuild
+	useJUnitPlatform()
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath
+	systemProperty 'xp.script-engine', 'GraalJS'
+	shouldRunAfter test
+}
+
+check.dependsOn testGraalJs

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ dependencies {
 	testImplementation "com.enonic.xp:testing:${xpVersion}"
 	testImplementation 'org.junit.jupiter:junit-jupiter:6.1.1'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 
@@ -179,15 +178,6 @@ test {
 	useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-	group = 'verification'
-	description = 'Runs tests with the GraalJS script engine.'
-	dependsOn npmBuild
-	useJUnitPlatform()
-	testClassesDirs = sourceSets.test.output.classesDirs
-	classpath = sourceSets.test.runtimeClasspath
-	systemProperty 'xp.script-engine', 'GraalJS'
-	shouldRunAfter test
+xp {
+	scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ projectName=explorer
 appName=com.enonic.app.explorer
 rootProjectName=explorer
 
-xpVersion=8.0.2
+xpVersion=8.1.0-SNAPSHOT
 
 nodeVersion=24.18.0
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'com.enonic.xp.settings' version '4.1.0'
+	id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = rootProjectName

--- a/src/main/resources/services/graphQL/collection/addMutationCollectionDelete.ts
+++ b/src/main/resources/services/graphQL/collection/addMutationCollectionDelete.ts
@@ -14,7 +14,6 @@ import { listExplorerJobsThatStartWithName } from '/lib/explorer/scheduler/listE
 import { GraphQLBoolean } from '/lib/graphql';
 import { delete as deleteRepo } from '/lib/xp/repo';
 import { delete as deleteJob } from '/lib/xp/scheduler';
-import { executeFunction } from '/lib/xp/task';
 import {
 	GQL_MUTATION_COLLECTION_DELETE_NAME,
 	GQL_TYPE_NODE_DELETED_NAME
@@ -57,36 +56,26 @@ export default function addMutationCollectionDelete({glue}) {
 				throw new Error(`id:${_id} not a collection!`);
 			}
 
-			executeFunction({
-				description: `Delete any scheduled job relating to collection with path:${collectionNode._path}`,
-				func: () => {
-					const jobName = `${APP_EXPLORER}.${collectionNode._id}`;
-					const explorerJobsThatStartWithName = listExplorerJobsThatStartWithName({name: jobName});
-					log.debug('collection path:%s explorerJobsThatStartWithName:%s', collectionNode._path, toStr(explorerJobsThatStartWithName));
-					explorerJobsThatStartWithName.forEach(({name}) => {
-						log.info(`Deleting job name:${name}, while deleting collection with path:${collectionNode._path}`);
-						deleteJob({name});
-					});
-				}
+			const jobName = `${APP_EXPLORER}.${collectionNode._id}`;
+			const explorerJobsThatStartWithName = listExplorerJobsThatStartWithName({name: jobName});
+			log.debug('collection path:%s explorerJobsThatStartWithName:%s', collectionNode._path, toStr(explorerJobsThatStartWithName));
+			explorerJobsThatStartWithName.forEach(({name}) => {
+				log.info(`Deleting job name:${name}, while deleting collection with path:${collectionNode._path}`);
+				deleteJob({name});
 			});
 
 			if (boolDeleteRepo) {
 				const repoName = `${COLLECTION_REPO_PREFIX}${collectionNode._name}`;
-				executeFunction({
-					description: `Delete repo with name:${repoName}`,
-					func: () => {
-						log.info('Deleting repo with name:%s...', repoName);
-						if (deleteRepo(repoName)) {
-							log.info('Repo with name:%s, deleted.', repoName);
-						} else {
-							log.warning(
-								'Repository with name:%s was not found! While deleteing collection with path:%s',
-								repoName,
-								collectionNode._path
-							);
-						}
-					}
-				});
+				log.info('Deleting repo with name:%s...', repoName);
+				if (deleteRepo(repoName)) {
+					log.info('Repo with name:%s, deleted.', repoName);
+				} else {
+					log.warning(
+						'Repository with name:%s was not found! While deleteing collection with path:%s',
+						repoName,
+						collectionNode._path
+					);
+				}
 			}
 
 			const deleteCollectionRes = writeConnection.delete(_id);

--- a/src/test/java/com/enonic/app/explorer/AddMutationCollectionDeleteTest.java
+++ b/src/test/java/com/enonic/app/explorer/AddMutationCollectionDeleteTest.java
@@ -1,0 +1,13 @@
+package com.enonic.app.explorer;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class AddMutationCollectionDeleteTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/graphql/addMutationCollectionDelete.test.js";
+    }
+}

--- a/src/test/resources/graphql/addMutationCollectionDelete.test.js
+++ b/src/test/resources/graphql/addMutationCollectionDelete.test.js
@@ -1,0 +1,82 @@
+var assert = require('/lib/xp/testing');
+var connectMock = require('/lib/explorer/repo/connect');
+var listJobsMock = require('/lib/explorer/scheduler/listExplorerJobsThatStartWithName');
+var schedulerMock = require('/lib/xp/scheduler');
+var repoMock = require('/lib/xp/repo');
+var addMutationCollectionDelete = require('/services/graphQL/collection/addMutationCollectionDelete').default;
+
+var COLLECTION_NODE_TYPE = 'com.enonic.app.explorer:collection';
+var COLLECTION_ID = 'collection-id-1';
+var COLLECTION_NAME = 'mycollection';
+var JOB_NAME = 'com.enonic.app.explorer.' + COLLECTION_ID;
+var REPO_NAME = 'com.enonic.app.explorer.collection.' + COLLECTION_NAME;
+
+function registerMutation() {
+    var captured = null;
+    var glue = {
+        addMutation: function (config) {
+            captured = config;
+        },
+        getScalarType: function () {
+            return {};
+        },
+        getObjectType: function () {
+            return {};
+        }
+    };
+    addMutationCollectionDelete({glue: glue});
+    return captured;
+}
+
+exports.before = function () {
+    connectMock.__reset();
+    listJobsMock.__reset();
+    schedulerMock.__reset();
+    repoMock.__reset();
+    connectMock.__setNode({
+        _id: COLLECTION_ID,
+        _name: COLLECTION_NAME,
+        _path: '/collections/' + COLLECTION_NAME,
+        _nodeType: COLLECTION_NODE_TYPE
+    });
+};
+
+exports.testDeletesJobsRepoAndCollectionInline = function () {
+    listJobsMock.__setJobs([{name: JOB_NAME}]);
+
+    var mutation = registerMutation();
+    var result = mutation.resolve({args: {_id: COLLECTION_ID, deleteRepo: true}});
+
+    assert.assertEquals(JOB_NAME, listJobsMock.__queriedNames()[0]);
+    assert.assertEquals(1, schedulerMock.__deletedNames().length);
+    assert.assertEquals(JOB_NAME, schedulerMock.__deletedNames()[0]);
+
+    assert.assertEquals(1, repoMock.__deletedRepos().length);
+    assert.assertEquals(REPO_NAME, repoMock.__deletedRepos()[0]);
+
+    assert.assertEquals(1, connectMock.__deleteCalls().length);
+    assert.assertEquals(COLLECTION_ID, connectMock.__deleteCalls()[0]);
+    assert.assertEquals(1, connectMock.__refreshCalls());
+    assert.assertEquals(COLLECTION_ID, result._id);
+};
+
+exports.testDoesNotTouchRepoWhenDeleteRepoIsFalse = function () {
+    listJobsMock.__setJobs([{name: JOB_NAME}]);
+
+    var mutation = registerMutation();
+    var result = mutation.resolve({args: {_id: COLLECTION_ID, deleteRepo: false}});
+
+    assert.assertEquals(1, schedulerMock.__deletedNames().length);
+    assert.assertEquals(0, repoMock.__deletedRepos().length);
+    assert.assertEquals(1, connectMock.__deleteCalls().length);
+    assert.assertEquals(COLLECTION_ID, result._id);
+};
+
+exports.testDeletesEveryMatchingJob = function () {
+    listJobsMock.__setJobs([{name: JOB_NAME}, {name: JOB_NAME + '.sub'}]);
+
+    var mutation = registerMutation();
+    mutation.resolve({args: {_id: COLLECTION_ID, deleteRepo: false}});
+
+    assert.assertEquals(2, schedulerMock.__deletedNames().length);
+};

--- a/src/test/resources/lib/explorer/repo/connect.js
+++ b/src/test/resources/lib/explorer/repo/connect.js
@@ -1,0 +1,43 @@
+var node = null;
+var getCalls = [];
+var deleteCalls = [];
+var refreshCalls = 0;
+
+exports.connect = function () {
+    return {
+        get: function (id) {
+            getCalls.push(id);
+            return node;
+        },
+        delete: function (id) {
+            deleteCalls.push(id);
+            return [id];
+        },
+        refresh: function () {
+            refreshCalls += 1;
+        }
+    };
+};
+
+exports.__setNode = function (value) {
+    node = value;
+};
+
+exports.__getCalls = function () {
+    return getCalls;
+};
+
+exports.__deleteCalls = function () {
+    return deleteCalls;
+};
+
+exports.__refreshCalls = function () {
+    return refreshCalls;
+};
+
+exports.__reset = function () {
+    node = null;
+    getCalls.length = 0;
+    deleteCalls.length = 0;
+    refreshCalls = 0;
+};

--- a/src/test/resources/lib/explorer/scheduler/listExplorerJobsThatStartWithName.js
+++ b/src/test/resources/lib/explorer/scheduler/listExplorerJobsThatStartWithName.js
@@ -1,0 +1,20 @@
+var jobs = [];
+var queriedNames = [];
+
+exports.listExplorerJobsThatStartWithName = function (params) {
+    queriedNames.push(params.name);
+    return jobs;
+};
+
+exports.__setJobs = function (value) {
+    jobs = value;
+};
+
+exports.__queriedNames = function () {
+    return queriedNames;
+};
+
+exports.__reset = function () {
+    jobs = [];
+    queriedNames.length = 0;
+};

--- a/src/test/resources/lib/graphql.js
+++ b/src/test/resources/lib/graphql.js
@@ -1,0 +1,3 @@
+exports.GraphQLBoolean = {
+    __type: 'Boolean'
+};

--- a/src/test/resources/lib/xp/repo.js
+++ b/src/test/resources/lib/xp/repo.js
@@ -1,0 +1,20 @@
+var deletedRepos = [];
+var exists = true;
+
+exports.delete = function (repoName) {
+    deletedRepos.push(repoName);
+    return exists;
+};
+
+exports.__deletedRepos = function () {
+    return deletedRepos;
+};
+
+exports.__setExists = function (value) {
+    exists = value;
+};
+
+exports.__reset = function () {
+    deletedRepos.length = 0;
+    exists = true;
+};

--- a/src/test/resources/lib/xp/scheduler.js
+++ b/src/test/resources/lib/xp/scheduler.js
@@ -1,0 +1,14 @@
+var deletedNames = [];
+
+exports.delete = function (params) {
+    deletedNames.push(params.name);
+    return true;
+};
+
+exports.__deletedNames = function () {
+    return deletedNames;
+};
+
+exports.__reset = function () {
+    deletedNames.length = 0;
+};

--- a/src/test/resources/lib/xp/task.js
+++ b/src/test/resources/lib/xp/task.js
@@ -1,0 +1,7 @@
+exports.executeFunction = function () {
+    throw new Error('task.executeFunction is deprecated and fails fast on GraalJS - the collection-delete cleanup must run inline');
+};
+
+exports.submitTask = function () {
+    throw new Error('task.submitTask was not expected in the collection-delete resolver');
+};


### PR DESCRIPTION
Fixes #1082

## Route taken: inline (not named tasks)

The issue offers two routes for the two `task.executeFunction` calls in
`services/graphQL/collection/addMutationCollectionDelete.ts` (:60, :75) and asks to pick one.

I took the **inline** route, which the issue recommends for this site:

> Both are cleanup steps of an explicit, destructive admin action whose result nobody polls, and
> both are short. **Calling them directly is the simplest correct fix** — a user deleting a
> collection can wait for its jobs and repo to go, and doing it inline also means a failure
> surfaces in the mutation instead of vanishing into a task nobody reads.

So both closures now run synchronously in the resolver, in place, and the resolver no longer
imports `/lib/xp/task`. Ordering is unchanged from the source (jobs → repo → collection node →
refresh), and because it is inline a failure in job/repo deletion now aborts the mutation with an
error instead of deleting the collection node anyway and losing the failure in a task log.

No behavior was moved into a named task, so there is no `config` serialization to worry about; the
"pass ids, re-read inside the task" guidance did not apply once the calls were inlined.

## Dual-engine test wiring

`build.gradle` now runs the JS tests once per script engine — Nashorn via `test`, GraalJS via
`testGraalJs` — both wired into `check`, mirroring the reference in enonic/lib-sql#154:

```groovy
testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'

def testGraalJs = tasks.register('testGraalJs', Test) { … systemProperty 'xp.script-engine', 'GraalJS' … }
check.dependsOn testGraalJs
```

`xpVersion` is bumped `8.0.2 → 8.1.0-SNAPSHOT` and the build already resolves `xp.enonicRepo('dev')`
— both are required by `testGraalJs`, not by the fix itself (the `ScriptRunnerSupport` change from
enonic/xp#12198). `compileTestJava` gets an explicit `dependsOn npmBuild` because Gradle 9 flags the
compiled bundle in `build/resources/main` as an undeclared input otherwise.

## What the test actually exercises

`AddMutationCollectionDeleteTest` extends `ScriptRunnerSupport` and runs
`src/test/resources/graphql/addMutationCollectionDelete.test.js`, which:

- `require`s the **real compiled resolver** (`/services/graphQL/collection/addMutationCollectionDelete`,
  produced by `npmBuild`) — not a hand-written copy — and drives its `resolve()`;
- provides thin mock `/lib` modules (`/lib/xp/repo`, `/lib/xp/scheduler`, `/lib/explorer/repo/connect`,
  `/lib/explorer/scheduler/listExplorerJobsThatStartWithName`, `/lib/graphql`) that record calls;
- asserts the scheduled jobs, the collection repo and the collection node are all deleted
  synchronously, and that the repo is left alone when `deleteRepo:false`.

The assertions check values computed **inside** the compiled resolver from the bundled
`@enonic/explorer-utils` constants (`jobName = com.enonic.app.explorer.<id>`,
`repoName = com.enonic.app.explorer.collection.<name>`), so a green run means the real resolver ran,
not a stub. A dormant `/lib/xp/task` mock throws if `executeFunction`/`submitTask` is ever
reintroduced into this resolver, so the closure form cannot silently come back.

**Honest scope note (per the issue):** this drives the real resolver on both real engines with
mocked leaf libraries — it does **not** run end-to-end against a live XP with real repos, a real
scheduler and real content. The async→inline change and its engine-independence are what is
verified; a full E2E of the delete against a running server is not.

## Local verification

Built XP `8.1.0-SNAPSHOT` (branch `claude/graaljs-support-limitations-pzu6z8`, enonic/xp#12198) to
`mavenLocal` with a GraalVM Community 25 JDK, then:

```
./gradlew test testGraalJs
:test         AddMutationCollectionDeleteTest  tests=3  failures=0  errors=0   (Nashorn)
:testGraalJs  AddMutationCollectionDeleteTest  tests=3  failures=0  errors=0   (GraalJS)
```

## Draft — CI `testGraalJs` stays red until the platform snapshot ships

This is held as a **draft**: `testGraalJs` depends on the `ScriptRunnerSupport` fix in
enonic/xp#12198, which is not yet merged/published. Until a fresh `8.1.0-SNAPSHOT` carrying it lands
on `repo.enonic.com/dev`, CI `testGraalJs` will fail at test discovery (`The Context is already
closed`) regardless of this app's code — exactly as in enonic/lib-sql#154. Nashorn `test` is
unaffected. Verified green above against a local build of that branch.